### PR TITLE
Support for passing in a custom string in `Other` TxError

### DIFF
--- a/motoko/src/token.mo
+++ b/motoko/src/token.mo
@@ -17,6 +17,7 @@ import Order "mo:base/Order";
 import Nat "mo:base/Nat";
 import Nat64 "mo:base/Nat64";
 import Result "mo:base/Result";
+import Text "mo:base/Text";
 import ExperimentalCycles "mo:base/ExperimentalCycles";
 import Cap "./cap/Cap";
 import Root "./cap/Root";
@@ -52,7 +53,7 @@ shared(msg) actor class Token(
             #Unauthorized;
             #LedgerTrap;
             #ErrorTo;
-            #Other;
+            #Other: Text;
             #BlockUsed;
             #AmountTooSmall;
         };

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -91,7 +91,7 @@ pub enum TxError {
     BlockUsed,
     ErrorOperationStyle,
     ErrorTo,
-    Other,
+    Other(String),
 }
 pub type TxReceipt = Result<Nat, TxError>;
 
@@ -710,7 +710,10 @@ async fn insert_into_cap_priv(ie: IndefiniteEvent) -> TxReceipt {
     let insert_res = insert(ie.clone())
         .await
         .map(|tx_id| Nat::from(tx_id))
-        .map_err(|_| TxError::Other);
+        .map_err(|error| TxError::Other(format!(
+            "Inserting into cap failed with error: {:?}",
+            error
+        )));
 
     if insert_res.is_err() {
         TXLOG.with(|t| {

--- a/rust/token.did
+++ b/rust/token.did
@@ -23,9 +23,9 @@ type TxError = variant {
   Unauthorized;
   LedgerTrap;
   ErrorTo;
-  Other;
   BlockUsed;
   AmountTooSmall;
+  Other : text;
 };
 service : (
   text,

--- a/spec.md
+++ b/spec.md
@@ -39,7 +39,7 @@ A standard token interface is a basic building block for many applications on th
             #Unauthorized;
             #LedgerTrap;
             #ErrorTo;
-            #Other;
+            #Other: Text;
             #BlockUsed;
             #AmountTooSmall;
        };


### PR DESCRIPTION
This will extend the usage of the enum type `TxError::Other` to support arbitrary strings. This will help in surfacing errors coming from cap or anything else. 

Ex:
```
TxError::Other(format!(
            "Inserting into cap failed with error: {:?}",
            error
        ))
```